### PR TITLE
Use Inter variable font when supported

### DIFF
--- a/src/style/global.js
+++ b/src/style/global.js
@@ -12,9 +12,13 @@ export const globalStyles = css`
     background-color: ${colors.bgMuted};
     color: ${colors.text};
     scroll-behavior: smooth;
-    
+
     @media (min-width: 50rem) {
       font-size: 100%;
+    }
+
+    @supports (font-variation-settings: normal) {
+      font-family: 'Inter var', Arial, sans-serif;
     }
   }
 


### PR DESCRIPTION
Use Inter variable font when supported in order to reduce the
number of requests made for font files.