### PR TITLE
Create pages for targets and pathologies

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,1 +1,10 @@
 import 'typeface-inter';
+
+export const shouldUpdateScroll = ({ routerProps }) => {
+  let sectionId = routerProps.location.pathname.replace(/\//g, '-').slice(1, -1);
+  if (document.getElementById(sectionId)) {
+    return sectionId;
+  }
+
+  return true;
+}

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,0 +1,70 @@
+const path = require(`path`);
+const slugify = require('slugify');
+
+exports.createPages = async ({ graphql, actions }) => {
+  const { createPage } = actions;
+  const targets = await graphql(`
+    query {
+      allResourcesYaml {
+        distinct(field: target)
+      }
+    }
+  `);
+
+  targets.data.allResourcesYaml.distinct.forEach(async (target) => {
+    const pathologies = await graphql(`
+      query {
+        allResourcesYaml(filter: {target: {eq: "${target}"}}) {
+          distinct(field: pathology)
+        }
+      }
+    `);
+
+    const pathologyPageList = pathologies.data.allResourcesYaml.distinct.map(pathology => {
+      const cleanPathology = slugify(pathology, {
+        remove: /[*+~.()'"!:@]/g,
+        lower: true
+      });
+
+      const url = `/${target}/${cleanPathology}/`;
+
+      return {
+        pathology,
+        url,
+        cleanPathology
+      };
+    });
+
+    const pathologyList = [
+      {
+        pathology: 'Tout',
+        url: `/${target}/`
+      },
+      ...pathologyPageList
+    ]
+
+    // create Target page
+    createPage({
+      path: `/${target}/`,
+      component: path.resolve('./src/components/TargetPage/index.js'),
+      context: {
+        target,
+        pathologyList
+      }
+    });
+
+    // create all pathologies pages
+    pathologyPageList.forEach(pathology => {
+      createPage({
+        path: pathology.url,
+        component: path.resolve('./src/components/PathologyPage/index.js'),
+        context: {
+          pathology: pathology.pathology,
+          target,
+          cleanPathology: pathology.cleanPathology,
+          pathologyList
+        }
+      });
+    });
+  });
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-helmet": "^5.2.1",
+    "slugify": "^1.4.0",
     "typeface-inter": "^3.12.0"
   }
 }

--- a/src/components/CategoryLinks/index.js
+++ b/src/components/CategoryLinks/index.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Link } from 'gatsby';
+import styled from '@emotion/styled';
+
+import { colors } from 'Style/colors';
+
+const CategoryLink = styled(Link)`
+  color: ${colors.textLight};
+  text-decoration: none;
+  text-transform: uppercase;
+  border: 1px solid ${colors.bgLight};
+  border-radius: 2rem;
+  background-color: ${colors.bgMuted};
+  margin: 0.5rem 0.8125rem;
+  padding: 0.625rem 1.625rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1.25;
+
+  :hover {
+    opacity: 0.8;
+  }
+
+  &.active {
+    color: ${colors.secondary};
+    border-color: ${colors.secondary};
+  }
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin: 1rem 0 0;
+`;
+
+const CategoryLinks = ({ links }) => {
+  return (
+    <Container>
+      {links.map(link => (
+        <CategoryLink to={link.url} activeClassName='active'>{link.pathology}</CategoryLink>
+      ))}
+    </Container>
+  );
+}
+
+export default CategoryLinks;

--- a/src/components/CategoryTitle/index.js
+++ b/src/components/CategoryTitle/index.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { H1, H2 } from 'Components/HTML';
+
+export const title = {
+  patients: 'Retrouvez les informations qui vous concernent',
+  praticiens: 'Découvrez tous les sites d’utilités essentielles',
+  etablissements: 'Parcourez les outils et les ressources à disposition'
+};
+export const subtitle = {
+  patients: 'Pour tous les patients',
+  praticiens: 'Pour tous les soignants, praticiens',
+  etablissements: 'Pour tous les établissements de santé'
+};
+
+const Subtitle = H2.withComponent('small');
+
+const CategoryTitle = ({ target }) => {
+  return (
+    <>
+      <H1>
+        {title[target]}
+        <Subtitle>{subtitle[target]}</Subtitle>
+      </H1>
+    </>
+  );
+}
+
+export default CategoryTitle;

--- a/src/components/EstablishmentsCards/index.js
+++ b/src/components/EstablishmentsCards/index.js
@@ -6,7 +6,7 @@ import CategoryCards from 'Components/CategoryCards';
 const EstablishmentsCards = () => {
   const resources = useStaticQuery(graphql`
     query EstablishmentsResources {
-      allResourcesYaml(filter: {target: {eq: "establishment"}}) {
+      allResourcesYaml(filter: {target: {eq: "etablissements"}}) {
         nodes {
           id
           link

--- a/src/components/HTML/h2.js
+++ b/src/components/HTML/h2.js
@@ -1,5 +1,15 @@
-import H1 from './h1';
+import styled from '@emotion/styled';
 
-const H2 = H1.withComponent('h2');
+import { colors } from 'Style/colors';
+
+const H2 = styled.h2`
+  display: block;
+  margin-bottom: 0.5rem;
+  font-size: 1.75rem;
+  line-height: 1.21428;
+  font-weight: 500;
+  color: ${colors.accent};
+  text-align: center;
+`;
 
 export default H2;

--- a/src/components/PathologyPage/index.js
+++ b/src/components/PathologyPage/index.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { graphql } from 'gatsby';
+
+import ResourcePageLayout from 'Components/ResourcePageLayout';
+import { subtitle } from 'Components/CategoryTitle';
+
+const PathologyPage = ({data, pageContext}) => {
+  const { pathology, cleanPathology, target, pathologyList } = pageContext;
+  const layoutContext = {
+    frontmatter: {
+      title: `${pathology} | ${subtitle[target]}`
+    }
+  }
+
+  return (
+    <ResourcePageLayout
+      layoutContext={layoutContext}
+      contentId={`${target}-${cleanPathology}`}
+      target={target}
+      links={pathologyList}
+      resources={data}
+    />
+  );
+}
+
+export const query = graphql`
+  query($pathology: String!, $target: String!,) {
+    allResourcesYaml(filter: {target: {eq: $target}, pathology: {eq: $pathology}}) {
+      nodes {
+        id
+        description
+        author
+        link
+        name
+        pathology
+        target
+      }
+    }
+  }
+`
+
+export default PathologyPage;

--- a/src/components/PatientCards/index.js
+++ b/src/components/PatientCards/index.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { useStaticQuery, graphql } from 'gatsby';
 
-import CategoryCards from 'Components/CategoryCards';
+import CategoryCards from "Components/CategoryCards";
 
 const PatientCards = () => {
   const resources = useStaticQuery(graphql`
     query PatientResources {
-      allResourcesYaml(filter: {target: {eq: "patient"}}) {
+      allResourcesYaml(filter: { target: { eq: "patients" } }) {
         nodes {
           id
           link
@@ -19,9 +19,7 @@ const PatientCards = () => {
     }
   `);
 
-  return (
-    <CategoryCards resources={resources} />
-  );
-}
+  return <CategoryCards resources={resources} />;
+};
 
 export default PatientCards;

--- a/src/components/ProfessionalCards/index.js
+++ b/src/components/ProfessionalCards/index.js
@@ -6,7 +6,7 @@ import CategoryCards from 'Components/CategoryCards';
 const ProfessionalCards = () => {
   const resources = useStaticQuery(graphql`
     query ProfessionalResources {
-      allResourcesYaml(filter: {target: {eq: "professional"}}) {
+      allResourcesYaml(filter: {target: {eq: "praticiens"}}) {
         nodes {
           id
           link

--- a/src/components/ResourcePageLayout/index.js
+++ b/src/components/ResourcePageLayout/index.js
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import Layout, { Content, FullWidthContent, Main } from 'Components/Layout';
+import TargetCards from 'Components/TargetCards';
+import CategoryTitle from 'Components/CategoryTitle';
+import CategoryLinks from 'Components/CategoryLinks';
+import CategoryCards from 'Components/CategoryCards';
+
+const ResourcePageLayout = ({
+  layoutContext,
+  contentId,
+  target,
+  links,
+  resources
+}) => {
+  return (
+    <Layout pageContext={layoutContext}>
+      <FullWidthContent>
+        <Main>
+          <Content>
+            <TargetCards/>
+          </Content>
+        </Main>
+      </FullWidthContent>
+      <Content id={contentId}>
+        <CategoryTitle target={target} />
+        <CategoryLinks links={links} />
+        <CategoryCards resources={resources} />
+      </Content>
+    </Layout>
+  );
+}
+
+export default ResourcePageLayout;

--- a/src/components/TargetCard/index.js
+++ b/src/components/TargetCard/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import { Link } from 'gatsby';
 
 import { colors } from 'Style/colors';
 import { ArrowRight } from 'Components/Icons';
@@ -18,11 +19,11 @@ const CardContainer = styled.li`
   align-items: center;
   font-size: 0.875rem;
   line-height: 1.0625rem;
-  
+
   :hover {
     opacity: .8;
   }
-  
+
   @media (min-width: 30rem) {
     min-width: 25rem;
   }
@@ -38,7 +39,7 @@ const TitleContainer = styled.div`
   font-weight: 600;
   height: 100%;
   color: ${colors.text};
-  
+
     @media (min-width: 30rem) {
       padding-left: 2rem;
     }
@@ -53,12 +54,12 @@ const LinkContainer = styled.div`
   min-width: 8.625rem;
   max-width: 8.625rem;
   height: 100%;
-  
+
   a {
     color: ${colors.accent};
     font-weight: 500;
     text-decoration: none;
-    
+
     &::after {
       content: '';
       position: absolute;
@@ -74,7 +75,7 @@ const Title = styled.h4`
   color: ${colors.primary};
   font-size: 1.25rem;
   line-height: 1.8125rem;
-  
+
     @media (min-width: 30rem) {
       font-size: 1.5rem;
     }
@@ -93,15 +94,14 @@ const TargetCard = ({title, link}) => (
         <Title>{title}</Title>
       </TitleContainer>
       <LinkContainer>
-        <a href={link} data-title={LINK_TEXT}>
+        <Link to={link} data-title={LINK_TEXT}>
           {LINK_TEXT}
           <IconContainer>
             <ArrowRight/>
           </IconContainer>
-        </a>
+        </Link>
       </LinkContainer>
     </CardContainer>
 )
 
 export default TargetCard;
-

--- a/src/components/TargetCards/index.js
+++ b/src/components/TargetCards/index.js
@@ -19,9 +19,9 @@ const CardsContainer = styled.ul`
 const TargetCards = () => {
   return (
       <CardsContainer>
-        <TargetCard title="Un patient" link="#patient"/>
-        <TargetCard title="Un praticien" link="#praticien"/>
-        <TargetCard title="Un établissement" link="#etablissement"/>
+        <TargetCard title="Un patient" link="/patients/"/>
+        <TargetCard title="Un praticien" link="/praticiens/"/>
+        <TargetCard title="Un établissement" link="/etablissements/"/>
       </CardsContainer>
   );
 }

--- a/src/components/TargetPage/index.js
+++ b/src/components/TargetPage/index.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { graphql } from 'gatsby';
+
+import ResourcePageLayout from 'Components/ResourcePageLayout';
+import { subtitle } from 'Components/CategoryTitle';
+
+const TargetPage = ({data, pageContext}) => {
+  const { target, pathologyList } = pageContext;
+  const layoutContext = {
+    frontmatter: {
+      title: subtitle[target]
+    }
+  }
+
+  return (
+    <ResourcePageLayout
+      layoutContext={layoutContext}
+      contentId={target}
+      target={target}
+      links={pathologyList}
+      resources={data}
+    />
+  );
+}
+
+export const query = graphql`
+  query($target: String!,) {
+    allResourcesYaml(filter: {target: {eq: $target}}) {
+      nodes {
+        id
+        description
+        author
+        link
+        name
+        pathology
+        target
+      }
+    }
+  }
+`
+
+export default TargetPage;

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -20,8 +20,8 @@ import EstablishmentsCards from 'Components/EstablishmentsCards';
 <Main>
 <Content id="patient">
 
-  ## Retrouvez les informations qui vous concernent
-  ### Pour tous les patients
+  # Retrouvez les informations qui vous concernent
+  ## Pour tous les patients
 
   <PatientCards />
 
@@ -33,8 +33,8 @@ import EstablishmentsCards from 'Components/EstablishmentsCards';
 <Main>
 <Content id="praticien">
 
-  ## Découvrez tous les sites d’utilités essentielles
-  ### Pour tous les soignants, praticiens
+  # Découvrez tous les sites d’utilités essentielles
+  ## Pour tous les soignants, praticiens
 
   <ProfessionalCards />
 
@@ -46,8 +46,8 @@ import EstablishmentsCards from 'Components/EstablishmentsCards';
 <Main>
 <Content id="etablissement">
 
-  ## Parcourez les outils et les ressources à disposition
-  ### Pour tous les établissements de santé
+  # Parcourez les outils et les ressources à disposition
+  ## Pour tous les établissements de santé
 
   <EstablishmentsCards />
 

--- a/src/resources/10-messages-cles-sfd.yaml
+++ b/src/resources/10-messages-cles-sfd.yaml
@@ -1,6 +1,6 @@
 name: 10 Messages clés SFD
 pathology: Diabètes
 description: Guidelines patients diabétiques
-target: patient
+target: patients
 link: https://bit.ly/39AINEZ
 author: D. Rosenbaum

--- a/src/resources/asso-patients-sfd.yaml
+++ b/src/resources/asso-patients-sfd.yaml
@@ -1,6 +1,6 @@
 name: Asso Patients SFD
 pathology: Diabètes
-description: Site de la fédération françaises des diabétiques
-target: patient
+description: Site de la fédération française des diabétiques
+target: patients
 link: https://www.federationdesdiabetiques.org/
 author: D. Rosenbaum

--- a/src/resources/asthme-allegies.yaml
+++ b/src/resources/asthme-allegies.yaml
@@ -1,6 +1,0 @@
-name: Asthme & Allegies
-pathology: Asthme
-description: "Site de l'association Asthme & Allegies : page dédiée et régulièrement mise à jour"
-target: patient
-link: https://asthme-allergies.org/informations-cornavirus-asthme/
-author: L. Pillot

--- a/src/resources/asthme-allergies.yaml
+++ b/src/resources/asthme-allergies.yaml
@@ -1,0 +1,6 @@
+name: Asthme & Allergies
+pathology: Asthme
+description: "Site de l'association Asthme & Allergies : page dédiée et régulièrement mise à jour"
+target: patients
+link: https://asthme-allergies.org/informations-cornavirus-asthme/
+author: L. Pillot

--- a/src/resources/comitehta.yaml
+++ b/src/resources/comitehta.yaml
@@ -1,6 +1,6 @@
 name: Comitehta
 pathology: Hypertension
 description: Site du comité français de lutte contre l'hypertension arterielle + tests observance
-target: patient
+target: patients
 link: https://www.comitehta.org/
 author: D. Rosenbaum

--- a/src/resources/covid19-medicaments.yaml
+++ b/src/resources/covid19-medicaments.yaml
@@ -1,6 +1,6 @@
 name: Covid 19 Médicaments
 pathology: Information
 description: Test à effectuer en cas de symptomes et prise de traitement
-target: patient
+target: patients
 link: https://www.covid19-medicaments.com
 author: F. Le Goff

--- a/src/resources/covidiab.yaml
+++ b/src/resources/covidiab.yaml
@@ -1,6 +1,6 @@
 name: CoviDIAB
 pathology: Diabètes
 description: Site d’accompagnement personnalisé, d’information et d’éducation dédié aux patients diabétiques face à la menace COVID-19
-target: patient
+target: patients
 link: https://www.covidiab.fr
 author: D. Rosenbaum

--- a/src/resources/depisthta.yaml
+++ b/src/resources/depisthta.yaml
@@ -1,6 +1,6 @@
 name: DepistHTA
 pathology: Hypertension
 description: Informations relatives au covid pour patients hypertendus
-target: patient
+target: patients
 link: https://www.depisthta.net
 author: D. Rosenbaum

--- a/src/resources/fondation-du-souflle.yaml
+++ b/src/resources/fondation-du-souflle.yaml
@@ -1,6 +1,6 @@
 name: Fondation du souffle
 pathology: Information
 description: "Site de la fondation du souffle : pour tout savoir sur le coronavirus"
-target: patient
+target: patients
 link: https://www.lesouffle.org/2020/03/03/pour-tout-savoir-sur-le-coronavirus/
 author: L. Pillot

--- a/src/resources/fondation-gregory-pariente.yaml
+++ b/src/resources/fondation-gregory-pariente.yaml
@@ -1,6 +1,6 @@
 name: Fondation Grégory Pariente
 pathology: Asthme
 description: "Site de la FGP : vidéo sur le coronavirus est-il dangereux pour l’asthmatique ?"
-target: patient
+target: patients
 link: http://gpfd.fr/
 author: L. Pillot

--- a/src/resources/sante-respiratoire-france.yaml
+++ b/src/resources/sante-respiratoire-france.yaml
@@ -1,6 +1,6 @@
 name: Santé Respiratoire France
 pathology: Maladies Respiratoires chroniques
 description: "Site de l'association Santé Respiratoire France : conseils sur la poursuite des traitements de fond"
-target: patient
+target: patients
 link: https://sante-respiratoire.com/
 author: L. Pillot

--- a/src/resources/sfpt.yaml
+++ b/src/resources/sfpt.yaml
@@ -1,6 +1,6 @@
 name: SFPT
 pathology: Information
 description: Foire aux questions concernant la prise de traitement et Covid 19
-target: patient
+target: patients
 link: https://www.pharmacol-fr.org/covid19-foire-aux-questions
 author: D. Rosenbaum

--- a/src/resources/sp2a.yaml
+++ b/src/resources/sp2a.yaml
@@ -1,6 +1,6 @@
 name: "SP2A : société pédiatrique de pneumologie et d'allergologie"
 pathology: Asthme (enfant)
 description: "Site de la SP2A : Comment protéger votre enfant atteint d’une maladie respiratoire chronique du nouveau coronavirus « Covid-19 »?"
-target: patient
+target: patients
 link: https://www.sp2a.fr/spa_actualites/comment-proteger-votre-enfant-atteint-dune-maladie-respiratoire-chronique-du-nouveau-coronavirus-covid-19/
 author: L. Pillot

--- a/src/resources/splf-asthme.yaml
+++ b/src/resources/splf-asthme.yaml
@@ -1,6 +1,6 @@
 name: "SPLF : Société de Pneumologie de Langue Française"
 pathology: Asthme
 description: "Site de la SPLF : Position du groupe de travail Asthme & Allergies  sur la prise en charge des asthmatiques pendant l'épidémie COVID 19"
-target: professional
+target: praticiens
 link: http://splf.fr/centre-de-documentation-covid-19/position-du-groupe-de-travai-asthme-et-allergies-de-la-splf-sur-la-prise-en-charge-des-asthmatiques-pendant-epidemie-de-covid-19-21-03-20/
 author: L. Pillot

--- a/src/resources/splf-respi.yaml
+++ b/src/resources/splf-respi.yaml
@@ -1,6 +1,6 @@
 name: "SPLF : Société de Pneumologie de Langue Française"
 pathology: Maladies Respi
 description: "Site de la SPLF : Centre de documentation COVID-19"
-target: professional
+target: praticiens
 link: http://splf.fr/centre-de-documentation-covid-19/
 author: L. Pillot

--- a/src/resources/vik-asthme.yaml
+++ b/src/resources/vik-asthme.yaml
@@ -1,6 +1,6 @@
 name: Vik Asthme
 pathology: Asthme
 description: Chatbot compagnon pour patient et aidants asthmatiques
-target: patient
+target: patients
 link: https://m.me/VikAsthme
 author: L. Pavillet

--- a/src/style/colors.js
+++ b/src/style/colors.js
@@ -3,9 +3,11 @@ export const colors = {
   secondary: '#FF8000',
   accent: '#FF8000',
   text: '#3B3B3B',
+  textLight: '#66696E',
   bg: '#F4F4F4',
   textHighlight: '#FFFFFF',
   bgHighlight: '#F9F9F9',
   bgPrimary: '#0069CC',
   bgMuted: '#FFF',
+  bgLight: '#E0E0E0',
 }


### PR DESCRIPTION
Create programmatically pages for targets and pathologies.
Add a layout component for these pages.
Remove static components for resources, used in the index page.
Add links between pathologies pages.
Rename targets in resources (target name is used in the url).