### PR TITLE
Add legal mentions internal page

### DIFF
--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -112,9 +112,9 @@ const Footer = () => {
             </li>
             <li>
               <LinkContainer>
-                <OutboundLink href="https://maladiecoronavirus.fr/mentions-legales" data-title="Mentions légales">
+                <Link to="/mentions-legales/" data-title="Mentions légales">
                   Mentions légales
-                </OutboundLink>
+                </Link>
               </LinkContainer>
             </li>
             <li>

--- a/src/components/HTML/Link.js
+++ b/src/components/HTML/Link.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+
+import { colors } from 'Style/colors';
+
+import { Link as RelativeLink } from 'gatsby';
+import OutboundLink from 'Components/OutboundLink';
+
+const linkStyle = css`
+  color: ${colors.secondary};
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const StyledRelativeLink = styled(RelativeLink)`${linkStyle}`;
+const StyledOutboundLink = styled(OutboundLink)`${linkStyle}`;
+
+const Link = ({href, ...props}) => {
+  if (href.startsWith('/')) {
+    return (
+      <StyledRelativeLink to={href} {...props} />
+    );
+  }
+
+  return (
+    <StyledOutboundLink href={href} {...props} />
+  );
+}
+
+export default Link;

--- a/src/components/HTML/h2.js
+++ b/src/components/HTML/h2.js
@@ -10,6 +10,10 @@ const H2 = styled.h2`
   font-weight: 500;
   color: ${colors.accent};
   text-align: center;
+
+  p + & {
+    margin-top: 1.5rem;
+  }
 `;
 
 export default H2;

--- a/src/components/HTML/index.js
+++ b/src/components/HTML/index.js
@@ -2,3 +2,4 @@ export { default as H1 } from './h1';
 export { default as H2 } from './h2';
 export { default as H3 } from './h3';
 export { default as P } from './p';
+export { default as Link } from './Link';

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -9,7 +9,7 @@ import { colors } from 'Style/colors';
 import SEO from 'Components/SEO';
 import Header from 'Components/Header';
 import Footer from 'Components/Footer';
-import { H1, H2, H3, P } from 'Components/HTML';
+import { H1, H2, H3, P, Link } from 'Components/HTML';
 
 // create components, here or somewhere else, with emotion styled
 const Container = styled.div`
@@ -51,7 +51,8 @@ const BaseLayout = ({children, pageContext}) => {
       h1: H1,
       h2: H2,
       h3: H3,
-      p: P
+      p: P,
+      a: Link
     }}>
       <Global styles={globalStyles} />
       <SEO title={title} description={description} />

--- a/src/pages/mentions-legales/index.mdx
+++ b/src/pages/mentions-legales/index.mdx
@@ -5,11 +5,12 @@ layout: article
 
 # Mentions Légales
 
+## Édition et Hébergement
 L’éditeur de ce site est la société KELINDI enregistrée sous le numéro 881 771 513 au RCS de LILLE METROPOLE. Le directeur de la publication est Monsieur Florian LE GOFF (presse@maladiecoronavirus.fr).  
 Ce site a été développé par la société DERNIER CRI enregistrée sous le numéro 524 671 260 au RCS de LILLE METROPOLE.  
 L'hébergeur du site est la société SCALINGO,SAS enregistrée sous le numéro 808 665 483 au RCS de STRASBOURG.
 
-Cookies et traceurs / Données à caractère personnel :  
+## Cookies et traceurs / Données à caractère personnel
 Aucune donnée à caractère personnel n'est traitée sur le Site outilscoronavirus.fr.  
 Aucun cookie ou traceur traitant de données à caractère personnel n'est référencé sur le Site outilscoronavirus.fr.  
 Le Site outilscoronavirus.fr recoure à la technologie simpleanalytics qui ne collecte aucune donnée à caractère personnel. Lien vers le détail des données collectées : https://docs.simpleanalytics.com/what-we-collect

--- a/src/pages/mentions-legales/index.mdx
+++ b/src/pages/mentions-legales/index.mdx
@@ -1,0 +1,15 @@
+---
+title: Mentions Légales
+layout: article
+---
+
+# Mentions Légales
+
+L’éditeur de ce site est la société KELINDI enregistrée sous le numéro 881 771 513 au RCS de LILLE METROPOLE. Le directeur de la publication est Monsieur Florian LE GOFF (presse@maladiecoronavirus.fr).  
+Ce site a été développé par la société DERNIER CRI enregistrée sous le numéro 524 671 260 au RCS de LILLE METROPOLE.  
+L'hébergeur du site est la société SCALINGO,SAS enregistrée sous le numéro 808 665 483 au RCS de STRASBOURG.
+
+Cookies et traceurs / Données à caractère personnel :  
+Aucune donnée à caractère personnel n'est traitée sur le Site outilscoronavirus.fr.  
+Aucun cookie ou traceur traitant de données à caractère personnel n'est référencé sur le Site outilscoronavirus.fr.  
+Le Site outilscoronavirus.fr recoure à la technologie simpleanalytics qui ne collecte aucune donnée à caractère personnel. Lien vers le détail des données collectées : https://docs.simpleanalytics.com/what-we-collect


### PR DESCRIPTION
Add legal mentions internal page.
Link legal mentions page in footer.
Add a Link component for markdown that manages internal and external
links.